### PR TITLE
Prevent scroll option for trading on mission AI

### DIFF
--- a/WAI/missions/bandit/captured_mv22.sqf
+++ b/WAI/missions/bandit/captured_mv22.sqf
@@ -24,7 +24,7 @@ if(isServer) then {
 	[[_position select 0,_position select 1,0],_rndnum,"Hard","Random",4,"Random","Hero","Random","Hero",_mission] call spawn_group;
 	[[_position select 0,_position select 1,0],_rndnum,"Hard","Random",4,"Random","Hero","Random","Hero",_mission] call spawn_group;
 	
-	[[_position select 0, _position select 1, 0],_rndnum,"Hard","Random",4,"Random","Doctor","Random",["Hero",200],_mission] call spawn_group;
+	[[_position select 0, _position select 1, 0],_rndnum,"Hard","Random",4,"Random","Doctor_DZ","Random",["Hero",200],_mission] call spawn_group;
 	 
 	//Static Guns
 	[[

--- a/WAI/missions/hero/crop_raider.sqf
+++ b/WAI/missions/hero/crop_raider.sqf
@@ -57,7 +57,7 @@ _baserunover = [_baserunover0,_baserunover1,_baserunover2,_baserunover3,_baserun
 _num = 4 + round (random 3);
 [[(_position select 0) + 9, (_position select 1) - 13, 0],_num,"Hard",["Random","AT"],4,"Random","Rocker3_DZ","Random","Bandit",_mission] call spawn_group;
 [[(_position select 0) + 13, (_position select 1) + 15, 0],4,"Hard","Random",4,"Random","Rocker1_DZ","Random","Bandit",_mission] call spawn_group;
-[[(_position select 0) - 23, (_position select 1) - 25, 0],4,"Hard","Random",4,"Random","Rocker4_DZ","Random","Bandit",_mission] call spawn_group;
+[[(_position select 0) - 23, (_position select 1) - 25, 0],4,"Hard","Random",4,"Random","Rocker2_DZ","Random","Bandit",_mission] call spawn_group;
 [[(_position select 0) - 13, (_position select 1) + 15, 0],4,"Hard","Random",4,"Random","Policeman","Random","Bandit",_mission] call spawn_group;
 [[_position select 0, _position select 1, 0],4,"Hard","Random",4,"Random","Policeman","Random","Bandit",_mission] call spawn_group;
 


### PR DESCRIPTION
There were some skins that are also used as trader so you were able to use a scroll option to trade with them, even if they are dead. I just fixed that with renaming the skins from WAI.