### PR TITLE
Fix error from malformed array

### DIFF
--- a/WAI/missions/hero/crop_raider.sqf
+++ b/WAI/missions/hero/crop_raider.sqf
@@ -72,7 +72,7 @@ _num = 4 + round (random 3);
 
 
 //Heli Paradrop
-[[(_position select 0), (_position select 1),[0,0,0],200,"UH1H_DZ",10,"Hard","Random",4,"Random","Bandit","Random","Bandit",true,_mission] spawn heli_para;
+[[(_position select 0), (_position select 1), 0],[0,0,0],200,"UH1H_DZ",10,"Hard","Random",4,"Random","Bandit","Random","Bandit",true,_mission] spawn heli_para;
 
 
 //Condition

--- a/WAI/missions/hero/crop_raider.sqf
+++ b/WAI/missions/hero/crop_raider.sqf
@@ -72,7 +72,7 @@ _num = 4 + round (random 3);
 
 
 //Heli Paradrop
-[[(_position select 0), (_position select 1), 0],200,"UH1H_DZ",10,"Hard","Random",4,"Random","Bandit","Random","Bandit",true,_mission] spawn heli_para;
+[[(_position select 0), (_position select 1),[0,0,0],200,"UH1H_DZ",10,"Hard","Random",4,"Random","Bandit","Random","Bandit",true,_mission] spawn heli_para;
 
 
 //Condition


### PR DESCRIPTION
 5:38:12 Error in expression <r _x) && (_x distance [_pos_x,_pos_y,0] <= _triggerdis)) then {
_player_present >
 5:38:12   Error position: <<= _triggerdis)) then {
_player_present >
 5:38:12   Error <=: Type String, expected Number
 5:38:12 File z\addons\dayz_server\WAI\compile\heli_para.sqf, line 43